### PR TITLE
Added strelka2 name to improve matching with presets

### DIFF
--- a/vidarrbuild.json
+++ b/vidarrbuild.json
@@ -1,5 +1,6 @@
 {
   "names": [
+    "strelka2",
     "strelka2_somatic",
     "strelka2_somatic_by_tumor_group"
   ],


### PR DESCRIPTION
We have **strelka2** in presets, however it is impossible to match with existing repo (**strelkaSomatic**) as it has only **strelka2_somatic** and **strelka2_somatic_by_tumor_group** aliases. Adding an alias to make things easier for pdd